### PR TITLE
Add timeUnit to requests and renaming of schema object

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(name='tap-amazon-ads-dsp',
           'backoff==1.8.0',
           'requests==2.23.0',
           'singer-python==5.8.1',
-          'pycurl==7.43.0.5',
           'requests_oauthlib==1.3.0',
       ],
       entry_points='''

--- a/tap_amazon_ads_dsp/schema.py
+++ b/tap_amazon_ads_dsp/schema.py
@@ -7,7 +7,7 @@ from singer import metadata
 
 LOGGER = singer.get_logger()
 
-REPORT_DIMENSION_METRICS = {
+REPORT_STREAMS = {
     "common": {
         "default_dimension_fields":
         ["entityId", "advertiserId"],
@@ -153,6 +153,7 @@ REPORT_DIMENSION_METRICS = {
         "replication_key": "date",
         "default_dimension_fields": ["date"],
         "dimensions": ["ORDER", "LINE_ITEM", "CREATIVE"],
+        "timeUnit": "DAILY",
         "fields": [
             "agencyFee", "totalFee", "3pFeeAutomotive",
             "3pFeeAutomotiveAbsorbed", "3pFeeComScore",
@@ -195,6 +196,7 @@ REPORT_DIMENSION_METRICS = {
         "replication_key": "date",
         "default_dimension_fields": ["date", "placementSize", "placementName"],
         "dimensions": ["ORDER", "LINE_ITEM", "SITE", "SUPPLY"],
+        "timeUnit": "DAILY",
         "fields": [
             "agencyFee", "totalFee", "3pFeeAutomotive",
             "3pFeeAutomotiveAbsorbed", "3pFeeComScore",
@@ -239,6 +241,7 @@ REPORT_DIMENSION_METRICS = {
         "default_dimension_fields":
         ["intervalStart", "intervalEnd", "segment"],
         "dimensions": ["ORDER", "LINE_ITEM"],
+        "timeUnit": "SUMMARY",
         "fields": [
             "segmentClassCode", "segmentSource", "segmentType",
             "segmentMarketplaceID", "targetingMethod"
@@ -323,12 +326,12 @@ def resolve_schema_references(schema, refs):
 def fields_for_report_dimensions(report_type, report_dimensions):
     report_primary_keys = []
     # All reports contains default
-    for field in REPORT_DIMENSION_METRICS['common'][
+    for field in REPORT_STREAMS['common'][
             'default_dimension_fields']:
         report_primary_keys.append(field)
     for dimension in report_dimensions:
         report_primary_keys.extend(DIMENSION_PRIMARY_KEYS.get(dimension).get('fields'))
-    for field in REPORT_DIMENSION_METRICS[report_type][
+    for field in REPORT_STREAMS[report_type][
             'default_dimension_fields']:
         report_primary_keys.append(field)
 
@@ -341,7 +344,7 @@ def fields_for_report_dimensions(report_type, report_dimensions):
 def get_report_dimensions(report):
     if report.get('dimensions'):
         return report.get('dimensions')
-    return REPORT_DIMENSION_METRICS.get(report.get('type')).get(
+    return REPORT_STREAMS.get(report.get('type')).get(
             'dimensions')
 
 def get_schemas(reports):
@@ -355,7 +358,7 @@ def get_schemas(reports):
         report_name = report.get('name')
         report_type = report.get('type')
         report_dimensions = get_report_dimensions(report)
-        replication_key = REPORT_DIMENSION_METRICS.get(report_type).get(
+        replication_key = REPORT_STREAMS.get(report_type).get(
             'replication_key')
 
         report_path = get_abs_path(f'schemas/{report_type.lower()}.json')

--- a/tap_amazon_ads_dsp/sync.py
+++ b/tap_amazon_ads_dsp/sync.py
@@ -8,7 +8,7 @@ from singer import Transformer, metadata, metrics, utils
 from singer.utils import strptime_to_utc
 from tap_amazon_ads_dsp.client import stream_csv
 from tap_amazon_ads_dsp.schema import (DIMENSION_FIELDS,
-                                       REPORT_DIMENSION_METRICS)
+                                       REPORT_STREAMS)
 from tap_amazon_ads_dsp.transform import transform_report
 
 LOGGER = singer.get_logger()
@@ -258,7 +258,7 @@ def sync_report(client,
         # Dimensions for API request
         api_dimensions = report_config.get(
             "dimensions",
-            REPORT_DIMENSION_METRICS.get(report_type).get("dimensions"))
+            REPORT_STREAMS.get(report_type).get("dimensions"))
 
         # Add selected metrics for API request
         selected_metrics = ""
@@ -271,6 +271,7 @@ def sync_report(client,
             "reportDate": window_start_str,
             "format": "CSV",
             "type": report_type.upper(),
+            "timeUnit": REPORT_STREAMS.get(report_type).get("timeUnit"),
             "dimensions": api_dimensions,
             "metrics": selected_metrics,
         }

--- a/tap_amazon_ads_dsp/transform.py
+++ b/tap_amazon_ads_dsp/transform.py
@@ -3,7 +3,7 @@ import json
 from decimal import Decimal
 
 import singer
-from tap_amazon_ads_dsp.schema import fields_for_report_dimensions, DIMENSION_PRIMARY_KEYS, REPORT_DIMENSION_METRICS
+from tap_amazon_ads_dsp.schema import fields_for_report_dimensions, DIMENSION_PRIMARY_KEYS, REPORT_STREAMS
 import decimal
 
 LOGGER = singer.get_logger()
@@ -27,7 +27,7 @@ def get_primary_keys(report_dimensions, report_type):
     for dim in report_dimensions:
         report_primary_keys.extend(DIMENSION_PRIMARY_KEYS.get(dim).get('primary_keys'))
     report_primary_keys.extend(DIMENSION_PRIMARY_KEYS.get('common').get('primary_keys'))
-    report_primary_keys.extend(REPORT_DIMENSION_METRICS.get(report_type).get('default_dimension_fields'))
+    report_primary_keys.extend(REPORT_STREAMS.get(report_type).get('default_dimension_fields'))
     return report_primary_keys
 
 # Transform for report_data in sync_report


### PR DESCRIPTION
# Description of change

- Adds `timeUnit` to all report requests due to API change. 
- Renames schema object.
- Remove `pycurl` dep, not needed.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
