### PR TITLE
Feature/download reports in order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.7
+  * Supporting API changes and process reports in order
+
 ## 0.0.6
   * Support string profile configs
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-amazon-ads-dsp',
-      version='0.0.6',
+      version='0.0.7',
       description='Singer.io tap for extracting data from the Amazon Advertising DSP v1.0 API',
       author='scott.coleman@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_amazon_ads_dsp/client.py
+++ b/tap_amazon_ads_dsp/client.py
@@ -105,7 +105,7 @@ class AmazonAdvertisingClient:
                 raise Exception("Unsupported HTTP method")
         except ConnectionError as ex:
             LOGGER.info(f"Connection error {ex}")
-            raise ConnectionError
+            raise ConnectionError(ex)
 
         LOGGER.info("Received code: {}".format(response.status_code))
 

--- a/tap_amazon_ads_dsp/schemas/campaign.json
+++ b/tap_amazon_ads_dsp/schemas/campaign.json
@@ -113,20 +113,12 @@
       "type": ["number", "null"],
       "multipleOf": 0.00001
     },
-    "totalNewToBrandProductSalesUSD14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
-    },
     "totalPercentOfPurchasesNewToBrand14d": {
       "type": ["null", "number"],
       "multipleOf": 0.0001
     },
     "totalAddToCart14d": {
       "type": ["null", "integer"]
-    },
-    "newToBrandProductSalesUSD14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
     },
     "totalNewToBrandROAS14d": {
       "type": ["number", "null"],
@@ -135,24 +127,12 @@
     "totalPurchasesViews14d": {
       "type": ["null", "integer"]
     },
-    "newToBrandProductSalesGBP14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
-    },
-    "totalSalesGBP14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
-    },
     "totalNewToBrandPurchaseRate14d": {
       "type": ["number", "null"],
       "multipleOf": 0.0001
     },
     "creativeType": {
       "type": ["null", "string"]
-    },
-    "newToBrandProductSalesJPY14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
     },
     "totalSubscribeAndSaveSubscriptionCPA14d": {
       "type": ["null", "number"],
@@ -184,16 +164,8 @@
       "type": ["null", "number"],
       "multipleOf": 0.00001
     },
-    "totalNewToBrandProductSalesJPY14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
-    },
     "totalNewToBrandUnitsSold14d": {
       "type": ["null", "integer"]
-    },
-    "totalNewToBrandProductSalesGBP14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
     },
     "totalAddToListViews14d": {
       "type": ["null", "integer"]
@@ -212,10 +184,6 @@
     "totalPRPVr14d": {
       "type": ["number", "null"],
       "multipleOf": 0.00001
-    },
-    "totalSalesJPY14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
     },
     "agencyFee": {
 			"type": ["null", "number"],
@@ -246,10 +214,6 @@
     "newToBrandUnitsSold14d": {
       "type": ["null", "integer"]
     },
-    "totalSalesUSD14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
-    },
     "3PFees": {
       "type": ["null", "number"],
       "multipleOf": 0.000001
@@ -257,10 +221,6 @@
     "totalPurchaseRate14d": {
       "type": ["number", "null"],
       "multipleOf": 0.0001
-    },
-    "salesGBP14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
     },
     "newToBrandERPM14d": {
       "type": ["number", "null"],
@@ -287,10 +247,6 @@
       "type": ["number", "null"],
       "multipleOf": 0.00001
     },
-    "salesUSD14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
-    },
     "totalPRPV14d": {
       "type": ["null", "number"],
       "multipleOf": 0.00001
@@ -298,10 +254,6 @@
     "totalDetaiPageViewCPA14d": {
       "type": ["null", "number"],
       "multipleOf": 0.00001
-    },
-    "salesJPY14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
     },
     "newToBrandROAS14d": {
       "type": ["number", "null"],

--- a/tap_amazon_ads_dsp/schemas/inventory.json
+++ b/tap_amazon_ads_dsp/schemas/inventory.json
@@ -113,20 +113,12 @@
       "type": ["number", "null"],
       "multipleOf": 0.00001
     },
-    "totalNewToBrandProductSalesUSD14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
-    },
     "totalPercentOfPurchasesNewToBrand14d": {
       "type": ["null", "number"],
       "multipleOf": 0.0001
     },
     "totalAddToCart14d": {
       "type": ["null", "integer"]
-    },
-    "newToBrandProductSalesUSD14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
     },
     "totalNewToBrandROAS14d": {
       "type": ["number", "null"],
@@ -135,24 +127,12 @@
     "totalPurchasesViews14d": {
       "type": ["null", "integer"]
     },
-    "newToBrandProductSalesGBP14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
-    },
-    "totalSalesGBP14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
-    },
     "placementName": {
       "type": ["null", "string"]
     },
     "totalNewToBrandPurchaseRate14d": {
       "type": ["number", "null"],
       "multipleOf": 0.0001
-    },
-    "newToBrandProductSalesJPY14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
     },
     "totalSubscribeAndSaveSubscriptionCPA14d": {
       "type": ["null", "number"],
@@ -184,19 +164,11 @@
       "type": ["null", "number"],
       "multipleOf": 0.00001
     },
-    "totalNewToBrandProductSalesJPY14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
-    },
     "totalNewToBrandPurchasesViews14d": {
       "type": ["null", "integer"]
     },
     "totalNewToBrandUnitsSold14d": {
       "type": ["null", "integer"]
-    },
-    "totalNewToBrandProductSalesGBP14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
     },
     "totalAddToListViews14d": {
       "type": ["null", "integer"]
@@ -215,10 +187,6 @@
     "totalPRPVr14d": {
       "type": ["number", "null"],
       "multipleOf": 0.0001
-    },
-    "totalSalesJPY14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
     },
     "agencyFee": {
 			"type": ["null", "number"],
@@ -250,10 +218,6 @@
     "totalPurchases14d": {
       "type": ["null", "integer"]
     },
-    "totalSalesUSD14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
-    },
     "3PFees": {
       "type": ["null", "number"],
       "multipleOf": 0.000001
@@ -261,10 +225,6 @@
     "totalPurchaseRate14d": {
       "type": ["number", "null"],
       "multipleOf": 0.0001
-    },
-    "salesGBP14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
     },
     "placementSize": {
       "type": ["null", "string"]
@@ -288,20 +248,12 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "salesUSD14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
-    },
     "totalROAS14d": {
       "type": ["number", "null"],
       "multipleOf": 0.00001
     },
     "unitsSold14d": {
       "type": ["null", "integer"]
-    },
-    "salesJPY14d": {
-			"type": ["null", "number"],
-			"multipleOf": 0.000001
     },
     "newToBrandROAS14d": {
       "type": ["number", "null"],


### PR DESCRIPTION
# Description of change

Updates to comply with API breaking changes:

* Report requests no longer use "reportDate": https://github.com/singer-io/tap-amazon-ads-dsp/compare/master...bytecodeio:feature/download_reports_in_order?expand=1#diff-17a7de06c9b26b92cc34a6c81814d961R271
* Currency specific fields removed from schema

This also changes method of downloading async reports. Reports are now downloaded in date order to allow for consistent resuming of interrupted extractions. 

# Manual QA steps

Performed sync through to configured destination and compared against expected data.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
