### PR TITLE
Handle equals signs returned in csv id columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.9
+  * Remove equals sign prefixes for ID fields from csv
+
 ## 0.0.8
   * Fail on authorization errors and increase backoff timings
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-amazon-ads-dsp',
-      version='0.0.8',
+      version='0.0.9',
       description='Singer.io tap for extracting data from the Amazon Advertising DSP v1.0 API',
       author='scott.coleman@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_amazon_ads_dsp/schemas/campaign.json
+++ b/tap_amazon_ads_dsp/schemas/campaign.json
@@ -194,7 +194,7 @@
       "multipleOf": 0.0001
     },
     "creativeID": {
-      "type": ["null", "integer"]
+      "type": ["null", "string"]
     },
     "3pFeeCPM2": {
 			"type": ["null", "number"],

--- a/tap_amazon_ads_dsp/schemas/shared/common.json
+++ b/tap_amazon_ads_dsp/schemas/shared/common.json
@@ -113,7 +113,7 @@
             "type": ["null", "string"]
         },
         "lineItemId": {
-            "type": ["null", "integer"]
+            "type": ["null", "string"]
         },
         "messageSentCPA14d": {
             "type": ["null", "number"],
@@ -439,7 +439,7 @@
             "type": ["null", "integer"]
         },
         "orderId": {
-            "type": ["null", "integer"]
+            "type": ["null", "string"]
         },
         "brandStoreEngagement3Clicks": {
             "type": ["null", "integer"]
@@ -1136,7 +1136,7 @@
 			"multipleOf": 0.0001
 		},
         "advertiserId": {
-            "type": ["null", "integer"]
+            "type": ["null", "string"]
         },
         "mashupClickToPage": {
             "type": ["null", "integer"]

--- a/tap_amazon_ads_dsp/transform.py
+++ b/tap_amazon_ads_dsp/transform.py
@@ -34,12 +34,19 @@ def get_primary_keys(report_dimensions, report_type):
 # - Add __sdc_record_hash
 # - Add report_date as API inconcistent across report type
 # - Convert percentage strings to decimals of schema defined precision
+# - ID fields returned with escaped equals sign prefix
+#   - "=""4788379690601""
+#   - Remove = and associated double quote escaping
 def transform_report(schema, report_type, report_date,
                      report_dimensions, report_data):
     report_primary_keys = get_primary_keys(report_dimensions, report_type)
 
     for record in report_data:
         primary_keys = build_primary_keys_for_record(report_primary_keys, record)
+        for key in primary_keys.keys():
+            transformed_value = primary_keys[key].lstrip('="').rstrip('"')
+            record[key] = transformed_value
+            primary_keys[key] = transformed_value
         dims_md5 = str(hash_data(json.dumps(primary_keys, sort_keys=True)))
         record['__sdc_record_hash'] = dims_md5
 


### PR DESCRIPTION
# Description of change
API now returns fields with prepended equals sign and double quote escaping for `advertiserId`, `creativeId`, `lineItemId` and `orderId`. This change transforms those to simple strings.

Ex:

```
"date","entityId","advertiserName","advertiserId"
"Jan 31, 2021","ENTITYXYZ","Demand Local","=""9999999999999"""
```

These changes strip the unwanted equals sign and double quote escaping.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
