### PR TITLE
Fix possible null exception when dealing with empty primary key values

### DIFF
--- a/tap_amazon_ads_dsp/__init__.py
+++ b/tap_amazon_ads_dsp/__init__.py
@@ -17,7 +17,7 @@ LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = [
     'client_id', 'client_secret', 'refresh_token', 'redirect_uri',
-    'start_date', 'reports'
+    'start_date', 'reports', 'profile_id'
 ]
 
 

--- a/tap_amazon_ads_dsp/__init__.py
+++ b/tap_amazon_ads_dsp/__init__.py
@@ -17,7 +17,7 @@ LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = [
     'client_id', 'client_secret', 'refresh_token', 'redirect_uri',
-    'start_date', 'profiles', 'reports'
+    'start_date', 'reports'
 ]
 
 

--- a/tap_amazon_ads_dsp/client.py
+++ b/tap_amazon_ads_dsp/client.py
@@ -8,6 +8,8 @@ import requests_oauthlib
 import singer
 import singer.metrics
 
+from ssl import SSLError, SSLZeroReturnError
+
 LOGGER = singer.get_logger()  # noqa
 
 TOKEN_URL = 'https://api.amazon.com/auth/o2/token'
@@ -132,7 +134,7 @@ class AmazonAdvertisingClient:
 
 
 # Stream CSV in batches of lines for transform and Singer write
-@backoff.on_exception(backoff.expo, (Server5xxError, ConnectionError),
+@backoff.on_exception(backoff.expo, (Server5xxError, ConnectionError, SSLError, SSLZeroReturnError),
                       max_tries=BACKOFF_MAX_TRIES,
                       factor=BACKOFF_FACTOR)
 def stream_csv(url, batch_size=1024):

--- a/tap_amazon_ads_dsp/client.py
+++ b/tap_amazon_ads_dsp/client.py
@@ -134,7 +134,7 @@ class AmazonAdvertisingClient:
 
 
 # Stream CSV in batches of lines for transform and Singer write
-@backoff.on_exception(backoff.expo, (Server5xxError, ConnectionError, SSLError, SSLZeroReturnError),
+@backoff.on_exception(backoff.expo, (Server5xxError, ConnectionError, SSLError, SSLZeroReturnError, requests.exceptions.RequestException),
                       max_tries=BACKOFF_MAX_TRIES,
                       factor=BACKOFF_FACTOR)
 def stream_csv(url, batch_size=1024):

--- a/tap_amazon_ads_dsp/client.py
+++ b/tap_amazon_ads_dsp/client.py
@@ -142,12 +142,14 @@ class AmazonAdvertisingClient:
     max_tries=BACKOFF_MAX_TRIES,
     factor=BACKOFF_FACTOR)
 def make_retryable_stream_request(url):
-    LOGGER.info(f"[{datetime.now().strftime("%H:%M:%S")}] @make_retryable_stream_request GET {url}")
+    now = datetime.now().strftime("%H:%M:%S")
+    LOGGER.info(f"[{now}] @make_retryable_stream_request GET {url}")
     return requests.get(url, stream=True)
 
 def stream_csv(url, batch_size=1024):
     try:
-        LOGGER.info(f"[{datetime.now().strftime("%H:%M:%S")}] @stream_csv GET {url}")
+        now = datetime.now().strftime("%H:%M:%S")
+        LOGGER.info(f"[{now}] @stream_csv GET {url}")
         with make_retryable_stream_request(url) as data:
             reader = csv.DictReader(
                 codecs.iterdecode(data.iter_lines(chunk_size=batch_size), "utf-8"))
@@ -161,5 +163,6 @@ def stream_csv(url, batch_size=1024):
             if batch:
                 yield batch
     except Exception as ex:
-        LOGGER.info(f"[{datetime.now().strftime("%H:%M:%S")}] @stream_csv Stream error {url}: {ex}")
+        now = datetime.now().strftime("%H:%M:%S")
+        LOGGER.info(f"[{now}] @stream_csv Stream error {url}: {ex}")
         raise ConnectionError(ex)

--- a/tap_amazon_ads_dsp/client.py
+++ b/tap_amazon_ads_dsp/client.py
@@ -175,6 +175,7 @@ def stream_csv(url, batch_size=1024):
     max_tries=BACKOFF_MAX_TRIES,
     factor=BACKOFF_FACTOR)
 def download_file(url, path):
+    now = datetime.now().strftime("%H:%M:%S")
     LOGGER.info(f"[{now}] @download_file GET {url} --> {path}")
     with requests.get(url, stream=True) as r:
         r.raise_for_status()

--- a/tap_amazon_ads_dsp/client.py
+++ b/tap_amazon_ads_dsp/client.py
@@ -146,6 +146,11 @@ def make_retryable_stream_request(url):
     LOGGER.info(f"[{now}] @make_retryable_stream_request GET {url}")
     return requests.get(url, stream=True)
 
+@backoff.on_exception(
+    backoff.expo,
+    (Server5xxError, ConnectionError, SSLError, SSLZeroReturnError, requests.exceptions.RequestException),
+    max_tries=BACKOFF_MAX_TRIES,
+    factor=BACKOFF_FACTOR)
 def stream_csv(url, batch_size=1024):
     try:
         now = datetime.now().strftime("%H:%M:%S")

--- a/tap_amazon_ads_dsp/sync.py
+++ b/tap_amazon_ads_dsp/sync.py
@@ -390,6 +390,9 @@ def sync_report(client,
 def sync(client, config, catalog, state):
     # Get config parameters
     profile_id = config.get('profile_id')
+    if profile_id is None: 
+        LOGGER.warn("No profile ID specified")
+        return
 
     start_date = config.get("start_date")
     reports = config.get("reports", [])

--- a/tap_amazon_ads_dsp/sync.py
+++ b/tap_amazon_ads_dsp/sync.py
@@ -389,9 +389,7 @@ def sync_report(client,
 # Sync - main function to loop through select streams to sync_endpoints and sync_reports
 def sync(client, config, catalog, state):
     # Get config parameters
-    profiles = config.get("profiles")
-    if isinstance(profiles, str):
-        profiles = profiles.replace(" ", "").split(",")
+    profile_id = config.get('profile_id')
 
     start_date = config.get("start_date")
     reports = config.get("reports", [])
@@ -418,47 +416,44 @@ def sync(client, config, catalog, state):
         if report_name in selected_streams:
             report_streams.append(report_name)
     LOGGER.info("Sync Report Streams: {}".format(report_streams))
+    LOGGER.info("Profile: {} - START Syncing".format(profile_id))
 
-    # PROFILE OUTER LOOP
-    for profile in profiles:
-        LOGGER.info("Profile: {} - START Syncing".format(profile))
+    # REPORT STREAMS LOOP
+    total_profile_records = 0
+    for report in reports:
+        report_name = report.get("name")
+        # if report_name in report_streams:
+        update_currently_syncing(state, report_name)
 
-        # REPORT STREAMS LOOP
-        total_profile_records = 0
-        for report in reports:
-            report_name = report.get("name")
-            # if report_name in report_streams:
-            update_currently_syncing(state, report_name)
+        LOGGER.info("Report: {} - START Syncing for Profile: {}".format(
+            report_name, profile_id))
 
-            LOGGER.info("Report: {} - START Syncing for Profile: {}".format(
-                report_name, profile))
+        # Write schema and log selected fields for stream
+        write_schema(catalog, report_name)
 
-            # Write schema and log selected fields for stream
-            write_schema(catalog, report_name)
+        selected_fields = get_selected_fields(catalog, report_name)
+        LOGGER.info("Report: {} - selected_fields: {}".format(
+            report_name, selected_fields))
 
-            selected_fields = get_selected_fields(catalog, report_name)
-            LOGGER.info("Report: {} - selected_fields: {}".format(
-                report_name, selected_fields))
+        total_records = sync_report(
+            client=client,
+            catalog=catalog,
+            state=state,
+            start_date=start_date,
+            report_name=report_name,
+            report_config=report,
+            tap_config=config,
+            profile=profile_id,
+            selected_fields=selected_fields,
+        )
 
-            total_records = sync_report(
-                client=client,
-                catalog=catalog,
-                state=state,
-                start_date=start_date,
-                report_name=report_name,
-                report_config=report,
-                tap_config=config,
-                profile=profile,
-                selected_fields=selected_fields,
-            )
+        total_profile_records = total_profile_records + total_records
+        # pylint: disable=line-too-long
+        LOGGER.info(
+            "Report: {} - FINISHED Syncing for Profile: {}, Total Records: {}"
+            .format(report_name, profile_id, total_records))
+        # pylint: enable=line-too-long
+        update_currently_syncing(state, None)
 
-            total_profile_records = total_profile_records + total_records
-            # pylint: disable=line-too-long
-            LOGGER.info(
-                "Report: {} - FINISHED Syncing for Profile: {}, Total Records: {}"
-                .format(report_name, profile, total_records))
-            # pylint: enable=line-too-long
-            update_currently_syncing(state, None)
-
-        LOGGER.info("Profile: {} - FINISHED Syncing, Total Records: {}".format(
-            profile, total_profile_records))
+    LOGGER.info("Profile: {} - FINISHED Syncing, Total Records: {}".format(
+        profile_id, total_profile_records))

--- a/tap_amazon_ads_dsp/transform.py
+++ b/tap_amazon_ads_dsp/transform.py
@@ -44,9 +44,10 @@ def transform_report(schema, report_type, report_date,
     for record in report_data:
         primary_keys = build_primary_keys_for_record(report_primary_keys, record)
         for key in primary_keys.keys():
-            transformed_value = primary_keys[key].lstrip('="').rstrip('"')
-            record[key] = transformed_value
-            primary_keys[key] = transformed_value
+            if primary_keys[key] is not None: 
+                transformed_value = primary_keys[key].lstrip('="').rstrip('"')
+                record[key] = transformed_value
+                primary_keys[key] = transformed_value
         dims_md5 = str(hash_data(json.dumps(primary_keys, sort_keys=True)))
         record['__sdc_record_hash'] = dims_md5
 


### PR DESCRIPTION
# Description of change
When running this tap locally in sync mode, I've noticed crashes happen due to an `.lstrip` attempt on a `None` value. I've traced it (using state-of-the-art LOGGER.info() statements) to a `primary_keys[key]` that equals `None`. Here's the printed value of `primary_keys` when this occurred (the crash occurred for the `placementSize` key):

```
INFO primary_keys: {'orderId': '2222488850301', 'lineItemId': '6186293480301', 'siteName': 'A&E Fire TV (ID: 959250bfde574750a32f212012947e3a)', 'supplySourceName': 'Amazon Publisher Services', 'entityId': 'ENTITY33T0UXQ5ENGIB', 'advertiserId': '5927600180701', 'date': 'Feb 17, 2021', 'placementSize': None, 'placementName': None}
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 0, "tags": {"endpoint": "inventory_report"}}
CRITICAL 'NoneType' object has no attribute 'lstrip'
Traceback (most recent call last):
  File "/usr/local/bin/tap-amazon-ads-dsp", line 8, in <module>
    sys.exit(main())
...
...
    transformed_value = primary_keys[key].lstrip('="').rstrip('"')
AttributeError: 'NoneType' object has no attribute 'lstrip'
```

# Manual QA steps
 - Run the tap locally
 
# Risks
 - Risk seems very low if any? The only cost incurred is in the [super negligible] performance hit
 
# Rollback steps
 - revert this branch
